### PR TITLE
Add csrf header setting that gets injected into headers

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -261,6 +261,7 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
             ? props.sessionHeaders
             : JSON.stringify(props.headers),
         credentials: props.settings['request.credentials'],
+        csrf: props.settings['csrf.header'],
       }
       const schema = await schemaFetcher.fetch(data)
       schemaFetcher.subscribe(data, newSchema => {

--- a/packages/graphql-playground-react/src/localDevIndex.tsx
+++ b/packages/graphql-playground-react/src/localDevIndex.tsx
@@ -95,7 +95,14 @@ const customLinkCreator = (
   session: LinkCreatorProps,
   wsEndpoint?: string,
 ): { link: ApolloLink } => {
-  const { headers, credentials } = session
+  let { headers } = session
+  const { credentials, csrf } = session
+  if (csrf) {
+    headers = {
+      ...headers,
+      [csrf.name]: csrf.value,
+    }
+  }
 
   const link = new HttpLink({
     uri: session.endpoint,

--- a/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
@@ -46,10 +46,16 @@ export function setSubscriptionEndpoint(endpoint) {
   subscriptionEndpoint = endpoint
 }
 
+export interface CsrfHeader {
+  name: string
+  value: string
+}
+
 export interface LinkCreatorProps {
   endpoint: string
   headers?: Headers
   credentials?: string
+  csrf?: CsrfHeader
 }
 
 export interface Headers {
@@ -61,7 +67,15 @@ export const defaultLinkCreator = (
   subscriptionEndpoint?: string,
 ): { link: ApolloLink; subscriptionClient?: SubscriptionClient } => {
   let connectionParams = {}
-  const { headers, credentials } = session
+  let { headers } = session
+  const { credentials, csrf } = session
+
+  if (csrf) {
+    headers = {
+      ...headers,
+      [csrf.name]: csrf.value,
+    }
+  }
 
   if (headers) {
     connectionParams = { ...headers }
@@ -137,6 +151,7 @@ function* runQuerySaga(action) {
   const lol = {
     endpoint: session.endpoint,
     headers,
+    csrf: settings['csrf.header'],
     credentials: settings['request.credentials'],
   }
 

--- a/packages/graphql-playground-react/src/state/sessions/sagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/sagas.ts
@@ -135,6 +135,7 @@ function* getSessionWithCredentials() {
     endpoint: session.endpoint,
     headers: session.headers,
     credentials: settings['request.credentials'],
+    csrf: settings['csrf.header'],
   }
 }
 

--- a/packages/graphql-playground-react/src/types.ts
+++ b/packages/graphql-playground-react/src/types.ts
@@ -16,7 +16,13 @@ export type Theme = 'dark' | 'light'
 
 export type CursorShape = 'line' | 'block' | 'underline'
 
+export interface CsrfHeader {
+  name: string
+  value: string
+}
+
 export interface ISettings {
+  ['csrf.header']?: CsrfHeader
   ['editor.cursorShape']: CursorShape
   ['editor.fontFamily']: string
   ['editor.fontSize']: number


### PR DESCRIPTION
This setting object contains the required name/value strings and can be
used to pass a CSRF header across different sessions and without needing
to inject headers into tabs (since headers will persist across
sessions).